### PR TITLE
Adds profiling of full multirun sweeps by following forks.

### DIFF
--- a/src/hydra_profiler/profiler.py
+++ b/src/hydra_profiler/profiler.py
@@ -2,6 +2,7 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 import hydra
 from hydra.experimental.callback import Callback
@@ -16,7 +17,7 @@ class ProfilerCallback(Callback):
     def __init__(self):
         self.memray_tracker = None
 
-    def on_multirun_start(self, config: DictConfig) -> None:
+    def on_multirun_start(self, config: DictConfig, **kwargs: Any) -> None:
         hydra_path = Path(hydra.core.hydra_config.HydraConfig.get().runtime.output_dir)
         memray_fp = hydra_path / "multirun.memray"
         self.memray_tracker = Tracker(memray_fp, follow_fork=True)
@@ -27,7 +28,7 @@ class ProfilerCallback(Callback):
         timings = {"start": st.isoformat()}
         timing_fp.write_text(json.dumps(timings))
 
-    def on_multirun_end(self, config: DictConfig) -> None:
+    def on_multirun_end(self, config: DictConfig, **kwargs: Any) -> None:
         hydra_path = Path(hydra.core.hydra_config.HydraConfig.get().runtime.output_dir)
         if self.memray_tracker is None:
             logger.warning("ProfilerCallback.on_multirun_end: self.memray_tracker is None!")
@@ -41,19 +42,45 @@ class ProfilerCallback(Callback):
         timings["duration_seconds"] = (end - datetime.fromisoformat(timings["start"])).total_seconds()
         timing_fp.write_text(json.dumps(timings))
 
-    def on_job_start(self, task_function: TaskFunction, config: DictConfig) -> None:
+    def on_run_start(self, config: DictConfig, **kwargs: Any) -> None:
+        config.hydra.runtime.output_dir
         hydra_path = Path(hydra.core.hydra_config.HydraConfig.get().runtime.output_dir)
-        job_name = hydra.core.hydra_config.HydraConfig.get().job.name
-        memray_fp = hydra_path / f"{job_name}.memray"
+        memray_fp = hydra_path / "run.memray"
         self.memray_tracker = Tracker(memray_fp)
         self.memray_tracker.__enter__()
 
         st = datetime.now()
-        timing_fp = hydra_path / f"{job_name}.timing.json"
+        timing_fp = hydra_path / "run.timing.json"
         timings = {"start": st.isoformat()}
         timing_fp.write_text(json.dumps(timings))
 
-    def on_job_end(self, config: DictConfig, job_return: hydra.core.utils.JobReturn) -> None:
+    def on_run_end(self, config: DictConfig, **kwargs: Any) -> None:
+        hydra_path = Path(config.hydra.runtime.output_dir)
+        if self.memray_tracker is None:
+            logger.warning("ProfilerCallback.on_run_end: self.memray_tracker is None!")
+        else:
+            # ERROR is here
+            self.memray_tracker.__exit__(None, None, None)
+        end = datetime.now()
+        timing_fp = hydra_path / "run.timing.json"
+        timings = json.loads(timing_fp.read_text())
+        timings["end"] = end.isoformat()
+        timings["duration_seconds"] = (end - datetime.fromisoformat(timings["start"])).total_seconds()
+        timing_fp.write_text(json.dumps(timings))
+
+    def on_job_start(self, task_function: TaskFunction, config: DictConfig, **kwargs: Any) -> None:
+        hydra_path = Path(hydra.core.hydra_config.HydraConfig.get().runtime.output_dir)
+        job_name = hydra.core.hydra_config.HydraConfig.get().job.name
+        memray_fp = hydra_path / f"job.{job_name}.memray"
+        self.memray_tracker = Tracker(memray_fp)
+        self.memray_tracker.__enter__()
+
+        st = datetime.now()
+        timing_fp = hydra_path / f"job.{job_name}.timing.json"
+        timings = {"start": st.isoformat()}
+        timing_fp.write_text(json.dumps(timings))
+
+    def on_job_end(self, config: DictConfig, job_return: hydra.core.utils.JobReturn, **kwargs: Any) -> None:
         hydra_path = Path(hydra.core.hydra_config.HydraConfig.get().runtime.output_dir)
         job_name = hydra.core.hydra_config.HydraConfig.get().job.name
         if self.memray_tracker is None:
@@ -62,7 +89,7 @@ class ProfilerCallback(Callback):
             self.memray_tracker.__exit__(None, None, None)
 
         end = datetime.now()
-        timing_fp = hydra_path / f"{job_name}.timing.json"
+        timing_fp = hydra_path / f"job.{job_name}.timing.json"
         timings = json.loads(timing_fp.read_text())
         timings["end"] = end.isoformat()
         timings["duration_seconds"] = (end - datetime.fromisoformat(timings["start"])).total_seconds()

--- a/src/hydra_profiler/profiler.py
+++ b/src/hydra_profiler/profiler.py
@@ -22,6 +22,11 @@ class ProfilerCallback(Callback):
         return {"memray_tracker": None}
 
     def on_multirun_start(self, config: DictConfig, **kwargs: Any) -> None:
+        if config.hydra.launcher._target_.split(".")[-1] == "BasicLauncher":
+            logger.warning(
+                "BasicLauncher detected, only performing job profiling as one tracker can exist per thread!"
+            )
+            return
         hydra_path = Path(config.hydra.run.dir)
         hydra_path.mkdir(parents=True, exist_ok=True)
         memray_fp = hydra_path / "multirun.memray"
@@ -37,6 +42,11 @@ class ProfilerCallback(Callback):
         logger.info(f"multirun: {hydra_path}")
 
     def on_multirun_end(self, config: DictConfig, **kwargs: Any) -> None:
+        if config.hydra.launcher._target_.split(".")[-1] == "BasicLauncher":
+            logger.warning(
+                "BasicLauncher detected, only performing job profiling as one tracker can exist per thread!"
+            )
+            return
         hydra_path = Path(config.hydra.run.dir)
         if self.memray_tracker is None:
             logger.warning("ProfilerCallback.on_multirun_end: self.memray_tracker is None!")


### PR DESCRIPTION
- [ ] TODO -- see if this works with meds-tab

storage/shared/mimic-iv/meds_tab_tutorial_task/meds_tab/mortality/in_hospital/first_24h




According to the [memray Tracking API](https://bloomberg.github.io/memray/api.html#api-usage), you can only have one tracker at a time. So when a user uses `--multirun`, this callback won't work if they use the default launcher (just use the main thread). So the user must use joblib


Ok so since you can only have one tracker per thread, why not do this:
- [x] If a user launches a multirun with a single thread, default to per job logging, as that can always be aggregated by the user as jobs are run serially.
- [x] If a user launches a normal run, `on_job_start` and `on_job_end` are used by default once so we are covered here
- [ ] If a user launches a multirun with a launcher, we store a multirun log and a per job log as well. Hopefully there's no issues with memray trackers on the multirun call tracking the jobs by following forks.

When memray is called like this with follow fork it works:
```bash
    memray run --follow-fork -m "MEDS_tabular_automl.scripts.tabularize_time_series" \
        --multirun \
        worker="range(0,$N_PARALLEL_WORKERS)" \
        hydra/launcher=joblib \
        "input_dir=${MIMICIV_MEDS_DIR}/data" "output_dir=$OUTPUT_TABULARIZATION_DIR/${TASK}" \
        do_overwrite=False "input_label_dir=${TASKS_DIR}/${TASK}/" log_name=time_series_tabularization \
        "tabularization.window_sizes=[${WINDOW_SIZES}]" "tabularization.aggs=[${AGGREGATIONS}]" "$@"
```

However when the tracker object is inistialized with `follow_fork=True` it does not follow the forked processes and I get the error:

```bash
WARNING: Failed to read RSS value from /proc/self/statm
WARNING: Failed to read RSS value from /proc/self/statm
Failed to detect RSS, deactivating tracking
WARNING: Failed to read RSS value from /proc/self/statm
Failed to detect RSS, deactivating tracking                                                                                                                                       
```

Seems this is a limitation of the memray tool: https://github.com/bloomberg/pytest-memray/issues/89

I think this pull request should be cancelled, as the multirun Tracker api does not support this workflow

Resolves issue #3 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced multi-run profiling that tracks memory usage and execution duration across multiple sessions.
  - Enhanced performance monitoring with detailed tracking of session start and end times, providing better insights during multi-run operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->