### PR TITLE
Adds a psutil profiler

### DIFF
--- a/src/hydra_profiler/psutil_profiler.py
+++ b/src/hydra_profiler/psutil_profiler.py
@@ -1,0 +1,102 @@
+import json
+import logging
+import os
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+
+import hydra
+from hydra.experimental.callback import Callback
+from hydra.types import TaskFunction
+from omegaconf import DictConfig
+import psutil
+
+logger = logging.getLogger(__name__)
+
+
+class MemorySampler:
+    def __init__(self, interval=1.0):
+        """
+        interval: Sampling interval in seconds.
+        """
+        self.interval = interval
+        self.data = []  # List of dicts, each with a timestamp and RSS value.
+        self._running = False
+        self._thread = None
+        self.process = psutil.Process(os.getpid())
+
+    def _sample(self):
+        while self._running:
+            timestamp = time.time()
+            rss = self.process.memory_info().rss
+            self.data.append({"timestamp": timestamp, "rss": rss})
+            time.sleep(self.interval)
+
+    def start(self):
+        if not self._running:
+            self._running = True
+            self._thread = threading.Thread(target=self._sample, daemon=True)
+            self._thread.start()
+
+    def stop(self):
+        self._running = False
+        if self._thread is not None:
+            self._thread.join()
+            self._thread = None
+
+    def get_stats(self):
+        if not self.data:
+            return {"average": 0, "peak": 0, "data": []}
+        rss_values = [point["rss"] for point in self.data]
+        average = sum(rss_values) / len(rss_values)
+        peak = max(rss_values)
+        return {"average": average, "peak": peak, "data": self.data}
+
+
+class ProfilerCallback(Callback):
+    def __init__(self, sampling_interval: float = 1.0):
+        self.mem_sampler = MemorySampler(interval=sampling_interval)
+
+    def on_job_start(self, task_function: TaskFunction, config: DictConfig) -> None:
+        hydra_cfg = hydra.core.hydra_config.HydraConfig.get()
+        hydra_path = Path(hydra_cfg.runtime.output_dir)
+        job_name = hydra_cfg.job.name
+
+        # Record start time
+        st = datetime.now()
+        timing_fp = hydra_path / f"{job_name}.timing.json"
+        timings = {"start": st.isoformat()}
+        timing_fp.write_text(json.dumps(timings))
+
+        # Start the memory sampler
+        self.mem_sampler.start()
+
+    def on_job_end(self, config: DictConfig, job_return: hydra.core.utils.JobReturn) -> None:
+        hydra_cfg = hydra.core.hydra_config.HydraConfig.get()
+        hydra_path = Path(hydra_cfg.runtime.output_dir)
+        job_name = hydra_cfg.job.name
+
+        # Stop the memory sampler and get stats
+        self.mem_sampler.stop()
+        mem_stats = self.mem_sampler.get_stats()
+
+        # Record end time and compute duration
+        end = datetime.now()
+        timing_fp = hydra_path / f"{job_name}.timing.json"
+        timings = json.loads(timing_fp.read_text())
+        timings["end"] = end.isoformat()
+        timings["duration_seconds"] = (end - datetime.fromisoformat(timings["start"])).total_seconds()
+        timing_fp.write_text(json.dumps(timings))
+
+        # Save both timing and memory stats
+        result = {
+            "timing": timings,
+            "memory_stats": {
+                "average_rss_bytes": mem_stats["average"],
+                "peak_rss_bytes": mem_stats["peak"],
+                "samples": mem_stats["data"],
+            },
+        }
+        result_fp = hydra_path / f"{job_name}.profile.json"
+        result_fp.write_text(json.dumps(result, indent=2))

--- a/src/hydra_profiler/psutil_profiler.py
+++ b/src/hydra_profiler/psutil_profiler.py
@@ -7,10 +7,10 @@ from datetime import datetime
 from pathlib import Path
 
 import hydra
+import psutil
 from hydra.experimental.callback import Callback
 from hydra.types import TaskFunction
 from omegaconf import DictConfig
-import psutil
 
 logger = logging.getLogger(__name__)
 

--- a/src/hydra_profiler/psutil_profiler.py
+++ b/src/hydra_profiler/psutil_profiler.py
@@ -56,9 +56,10 @@ class MemorySampler:
 
 class ProfilerCallback(Callback):
     def __init__(self, sampling_interval: float = 1.0):
-        self.mem_sampler = MemorySampler(interval=sampling_interval)
+        self.sampling_interval = sampling_interval
 
     def on_job_start(self, task_function: TaskFunction, config: DictConfig) -> None:
+        self.mem_sampler = MemorySampler(interval=self.sampling_interval)
         hydra_cfg = hydra.core.hydra_config.HydraConfig.get()
         hydra_path = Path(hydra_cfg.runtime.output_dir)
         job_name = hydra_cfg.job.name

--- a/tests/dummy_hydra_app.py
+++ b/tests/dummy_hydra_app.py
@@ -1,0 +1,12 @@
+# tests/dummy_hydra_app.py
+import time
+import hydra
+from omegaconf import DictConfig
+
+@hydra.main(config_path=None)
+def dummy_app(cfg: DictConfig):
+    # Simulate some work to allow the profiler to gather data.
+    time.sleep(0.5)
+
+if __name__ == '__main__':
+    dummy_app()

--- a/tests/dummy_hydra_app.py
+++ b/tests/dummy_hydra_app.py
@@ -1,12 +1,15 @@
 # tests/dummy_hydra_app.py
 import time
+
 import hydra
 from omegaconf import DictConfig
+
 
 @hydra.main(config_path=None)
 def dummy_app(cfg: DictConfig):
     # Simulate some work to allow the profiler to gather data.
     time.sleep(0.5)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     dummy_app()

--- a/tests/test_profiler_cli.py
+++ b/tests/test_profiler_cli.py
@@ -1,0 +1,73 @@
+import rootutils
+
+root = rootutils.setup_root(__file__, dotenv=True, pythonpath=True, cwd=True)
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+def test_cli_profiler_callback(tmp_path: Path):
+    """
+    This test performs the following steps:
+      1. Creates a temporary Hydra output directory.
+      2. Runs a dummy Hydra app with the override to use the profiler callback:
+         ++hydra.callbacks.profiler._target_=hydra_profiler.profiler.ProfilerCallback
+      3. Verifies that the expected output files (timing and profile JSON files)
+         are created and contain the necessary keys.
+    """
+    # Create a temporary output directory for Hydra to write files.
+    output_dir = tmp_path / "hydra_output"
+    output_dir.mkdir()
+
+    # Path to the dummy Hydra app.
+    dummy_app_path = Path("tests/dummy_hydra_app.py")
+    assert dummy_app_path.exists(), f"Dummy Hydra app not found at {dummy_app_path}"
+
+    # Construct the CLI command.
+    # - Use the current Python interpreter.
+    # - Run the dummy Hydra app.
+    # - Override hydra.run.dir to our temporary directory.
+    # - Add the override to set our profiler callback.
+    command = [
+        sys.executable,
+        str(dummy_app_path),
+        f"hydra.run.dir={output_dir}",
+        "++hydra.callbacks.profiler._target_=hydra_profiler.psutil_profiler.ProfilerCallback",
+        "++hydra.callbacks.psutil_profiler.sampling_interval=0.1",
+    ]
+
+    # Run the CLI command.
+    result = subprocess.run(command, capture_output=True, text=True)
+
+    # For debugging purposes, print output if the command fails.
+    if result.returncode != 0:
+        print("STDOUT:\n", result.stdout)
+        print("STDERR:\n", result.stderr)
+    assert result.returncode == 0, f"CLI command failed with error: {result.stderr}"
+
+    # Verify that the expected output files have been created.
+    # The callback should create files ending with .timing.json and .profile.json.
+    timing_files = list(output_dir.glob("*.timing.json"))
+    profile_files = list(output_dir.glob("*.profile.json"))
+    assert timing_files, "No timing file found in the Hydra output directory."
+    assert profile_files, "No profile file found in the Hydra output directory."
+
+    # Load and verify the timing file.
+    with timing_files[0].open("r") as tf:
+        timings = json.load(tf)
+    for key in ("start", "end", "duration_seconds"):
+        assert key in timings, f"Timing file is missing key '{key}'."
+
+    # Load and verify the profile file.
+    with profile_files[0].open("r") as pf:
+        profile = json.load(pf)
+    assert "timing" in profile, "Profile file is missing 'timing' information."
+    assert "memory_stats" in profile, "Profile file is missing 'memory_stats'."
+    mem_stats = profile["memory_stats"]
+    for key in ("average_rss_bytes", "peak_rss_bytes", "samples"):
+        assert key in mem_stats, f"Memory stats missing key '{key}'."
+    # Ensure that at least one sample was recorded.
+    assert isinstance(mem_stats["samples"], list) and mem_stats["samples"], "No memory samples were recorded."

--- a/tests/test_profiler_cli.py
+++ b/tests/test_profiler_cli.py
@@ -7,7 +7,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
 
 def test_cli_profiler_callback(tmp_path: Path):
     """

--- a/tests/test_profiler_unittest.py
+++ b/tests/test_profiler_unittest.py
@@ -1,0 +1,99 @@
+import json
+import time
+from pathlib import Path
+
+import pytest
+from omegaconf import DictConfig
+from hydra_profiler.psutil_profiler import ProfilerCallback
+
+# Import the callback from wherever you have defined it.
+# For example, if it's in a module named profiler_callback:
+# from profiler_callback import ProfilerCallback
+
+# For this example, we assume ProfilerCallback and MemorySampler are defined in the current module.
+# (Copy the definitions from your implementation if needed.)
+
+# --- Dummy Hydra Config Setup ---
+
+class DummyRuntime:
+    def __init__(self, output_dir: str):
+        self.output_dir = output_dir
+
+class DummyJob:
+    def __init__(self, name: str):
+        self.name = name
+
+class DummyHydraConfig:
+    def __init__(self, output_dir: str, job_name: str):
+        self.runtime = DummyRuntime(output_dir)
+        self.job = DummyJob(job_name)
+
+# --- Integration Test ---
+
+def test_profiler_callback(tmp_path: Path, monkeypatch):
+    """
+    This integration test does the following:
+      1. Overrides Hydra's config so that the output directory is a temporary path.
+      2. Instantiates the ProfilerCallback with a fast sampling interval.
+      3. Simulates a job run by calling on_job_start, sleeping briefly to collect samples,
+         then calling on_job_end.
+      4. Verifies that the timing file and the profile file exist and contain valid data.
+    """
+    # Create a dummy Hydra configuration with our temporary directory and a fixed job name.
+    dummy_config = DummyHydraConfig(str(tmp_path), "test_job")
+
+    # Override HydraConfig.get() so that our callback uses the dummy configuration.
+    from hydra.core.hydra_config import HydraConfig  # type: ignore
+    monkeypatch.setattr(HydraConfig, "get", lambda: dummy_config)
+
+    # Create dummy arguments for the callback methods.
+    dummy_task_function = lambda: None  # The callback doesn't use this in our implementation.
+    dummy_config_omegaconf: DictConfig = {}  # Not used in our implementation either.
+
+    # Instantiate the callback with a fast (0.1 second) sampling interval for testing.
+    callback = ProfilerCallback(sampling_interval=0.1)
+
+    # Call on_job_start to record the start time and kick off memory sampling.
+    callback.on_job_start(dummy_task_function, dummy_config_omegaconf)
+
+    # Simulate some job work (0.5 seconds). In a real job this would be doing real work.
+    time.sleep(0.5)
+
+    # Call on_job_end to stop the sampler and write the profile data.
+    callback.on_job_end(dummy_config_omegaconf, None)
+
+    # Define expected file paths (written to the dummy Hydra output directory).
+    timing_file = tmp_path / "test_job.timing.json"
+    profile_file = tmp_path / "test_job.profile.json"
+
+    # Check that the timing file exists.
+    assert timing_file.exists(), "Timing file was not created."
+
+    # Load the timing file and verify that it contains the expected keys.
+    with timing_file.open("r") as tf:
+        timings = json.load(tf)
+    assert "start" in timings, "Start time not recorded in timing file."
+    assert "end" in timings, "End time not recorded in timing file."
+    assert "duration_seconds" in timings, "Duration not recorded in timing file."
+    # Ensure the recorded duration is at least the sleep time.
+    assert timings["duration_seconds"] >= 0.5
+
+    # Check that the profile file exists.
+    assert profile_file.exists(), "Profile file was not created."
+
+    # Load the profile file and verify its contents.
+    with profile_file.open("r") as pf:
+        profile = json.load(pf)
+    assert "timing" in profile, "Profile file is missing timing information."
+    assert "memory_stats" in profile, "Profile file is missing memory statistics."
+    mem_stats = profile["memory_stats"]
+    for key in ("average_rss_bytes", "peak_rss_bytes", "samples"):
+        assert key in mem_stats, f"Memory stats missing '{key}'."
+    assert isinstance(mem_stats["samples"], list) and len(mem_stats["samples"]) > 0, "No memory samples were collected."
+
+    # Optionally, verify that sample timestamps are in increasing order and RSS values are integers.
+    samples = mem_stats["samples"]
+    timestamps = [sample["timestamp"] for sample in samples]
+    assert all(timestamps[i] <= timestamps[i + 1] for i in range(len(timestamps) - 1)), "Timestamps are not in order."
+    for sample in samples:
+        assert isinstance(sample["rss"], int), "RSS value in sample is not an integer."


### PR DESCRIPTION
This is lighter weight than memray and provides simpler logs for users who just want just a resident memory (peak and average) and time logs in a single json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a memory profiling capability that tracks average and peak usage alongside job timing, enabling enhanced performance analysis.
  - Added a sample Hydra application to demonstrate the new profiling functionality.

- **Tests**
  - Implemented comprehensive tests to verify that performance and memory metrics are correctly recorded and output in structured files.
  - Added integration tests for the profiling callback to ensure correct functionality within a simulated Hydra job context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->